### PR TITLE
changed slashed token calculation

### DIFF
--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -128,11 +128,12 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 
 	// Deduct from validator's bonded tokens and update the validator.
 	// Burn the slashed tokens from the pool account and decrease the total supply.
+	initialLiquidTokens := validator.TokensFromShares(validator.TotalLiquidShares).TruncateInt()
 	validator = k.RemoveValidatorTokens(ctx, validator, tokensToBurn)
 
 	// Proportionally deduct any liquid tokens from the global total
-	validatorLiquidRatio := validator.TotalLiquidShares.Quo(validator.DelegatorShares)
-	slashedLiquidTokens := validatorLiquidRatio.Mul(sdk.NewDecFromInt(slashAmount)).TruncateInt()
+	updatedLiquidTokens := validator.TokensFromShares(validator.TotalLiquidShares).TruncateInt()
+	slashedLiquidTokens := initialLiquidTokens.Sub(updatedLiquidTokens)
 	if err := k.DecreaseTotalLiquidStakedTokens(ctx, slashedLiquidTokens); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Previously when a slash occurred, the percentage of liquid shares to total shares was used to determine how many tokens to decrement from the global total
```
deduction = slashAmount * (liquid shares / delegator shares)
```

However, imprecision can cause this value to deviate slightly from what's expected. Instead, the number of new liquid tokens should be calculated and then the delta should be applied. This way the total liquid staked tokens remains at parity with the value you would get by re-calculating it. 
```
deduction = (old liquid tokens - new liquid tokens)
where liquid tokens is determined by using TokensFromShares
```