### PR TITLE
test: handle liquid staked coins in sim; update sim ops

### DIFF
--- a/types/simulation/account.go
+++ b/types/simulation/account.go
@@ -70,9 +70,8 @@ func FindAccount(accs []Account, address sdk.Address) (Account, bool) {
 func RandomFees(r *rand.Rand, ctx sdk.Context, spendableCoins sdk.Coins) (sdk.Coins, error) {
 	spendable := sdk.NewCoins()
 	// remove liquid staking denoms from spendable coins since fees cannot be paid in those denoms
-	valoperPrefix := fmt.Sprintf("%s%s%s", sdk.Bech32MainPrefix, sdk.PrefixValidator, sdk.PrefixOperator)
 	for _, coin := range spendableCoins {
-		if strings.Contains(coin.Denom, valoperPrefix) {
+		if strings.Contains(coin.Denom, sdk.Bech32PrefixValAddr) {
 			continue
 		}
 		spendable = append(spendable, coin)

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -785,6 +785,9 @@ func SimulateMsgTokenizeShares(ak types.AccountKeeper, bk types.BankKeeper, k ke
 		// check that tokenization would not exceed global cap
 		params := k.GetParams(ctx)
 		totalStaked := k.TotalBondedTokens(ctx).ToDec()
+		if totalStaked.IsZero() {
+			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgTokenizeShares, "cannot happend - no validators bonded if stake is 0.0"), nil, nil // skip
+		}
 		totalLiquidStaked := k.GetTotalLiquidStakedTokens(ctx).Add(tokenizeShareAmt).ToDec()
 		liquidStakedPercent := totalLiquidStaked.Quo(totalStaked)
 		if liquidStakedPercent.GT(params.GlobalLiquidStakingCap) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

While testing `gaia` integration with a [cosmos-sdk branch/PR](https://github.com/cosmos/cosmos-sdk/pull/16747) containing LSM functionality it was discovered that some non-determinism tests on `gaia` started failing.

Upon further inspection it was noted that the `simtypes.RandFees()` function sometimes tries to use the liquid staked token as a fee denomination.

I am unsure wether that's the correct behaviour, but I am suspecting it is not.

The issue is mainly concerning testing and simulations and was caught because `gaia` implements an `AnteHandler` that restricts the types of coins that can be used as fee denoms.

There was also a small inconsistency in `SimulateMsgTokenizeShares` which I addressed.

Reference to `gaia` PR with the LSM-ICS integration:
- https://github.com/cosmos/gaia/pull/2643

Please let me know if you find these changes acceptable or want further changes made.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
